### PR TITLE
refactor(db): workspace-driven data model (phase 1)

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,165 +1,132 @@
 PRAGMA journal_mode=WAL;
 
--- 1. runs — workflow run tracking
-CREATE TABLE IF NOT EXISTS runs (
-  id              TEXT PRIMARY KEY,
-  ticket          TEXT NOT NULL,
-  repo_path       TEXT NOT NULL,
-  repo_url        TEXT,
-  status          TEXT DEFAULT 'running' CHECK(status IN ('running','completed','failed','cancelled')),
-  current_stage   TEXT NOT NULL DEFAULT 'INIT',
-  description     TEXT,
-  failed_at_stage TEXT,
-  design_worktree TEXT,
-  design_branch   TEXT,
-  dev_worktree    TEXT,
-  dev_branch      TEXT,
-  preferences_json TEXT,
-  notify_channel  TEXT,
-  notify_to       TEXT,
-  design_agent    TEXT DEFAULT 'claude' CHECK(design_agent IN ('claude','codex')),
-  dev_agent       TEXT DEFAULT 'claude' CHECK(dev_agent IN ('claude','codex')),
-  created_at      TEXT NOT NULL,
-  updated_at      TEXT NOT NULL
-);
+-- ============================================================================
+-- Phase 1: Workspace-Driven Data Model
+-- Breaking rewrite — old tables (runs/steps/events/approvals/artifacts/jobs/
+-- merge_queue/turns/webhooks/agent_hosts) are dropped wholesale.
+-- ============================================================================
 
--- 2. steps — stage transition history
-CREATE TABLE IF NOT EXISTS steps (
-  id           INTEGER PRIMARY KEY AUTOINCREMENT,
-  run_id       TEXT NOT NULL REFERENCES runs(id),
-  from_stage   TEXT NOT NULL,
-  to_stage     TEXT NOT NULL,
-  triggered_by TEXT,
-  created_at   TEXT NOT NULL
-);
-
--- 3. events — audit log with tracing support
-CREATE TABLE IF NOT EXISTS events (
-  id           INTEGER PRIMARY KEY AUTOINCREMENT,
-  run_id       TEXT REFERENCES runs(id),
-  event_type   TEXT NOT NULL,
-  payload_json TEXT,
-  created_at   TEXT NOT NULL,
-  trace_id     TEXT,
-  job_id       TEXT,
-  span_type    TEXT DEFAULT 'system',
-  level        TEXT DEFAULT 'info',
-  duration_ms  INTEGER,
-  error_detail TEXT,
-  source       TEXT
-);
-
--- 4. approvals — gate approvals/rejections
-CREATE TABLE IF NOT EXISTS approvals (
-  id         INTEGER PRIMARY KEY AUTOINCREMENT,
-  run_id     TEXT NOT NULL REFERENCES runs(id),
-  gate       TEXT NOT NULL CHECK(gate IN ('req','design','dev')),
-  decision   TEXT NOT NULL CHECK(decision IN ('approved','rejected')),
-  by         TEXT NOT NULL,
-  comment    TEXT,
-  created_at TEXT NOT NULL,
-  UNIQUE(run_id, gate, created_at)
-);
-
--- 5. webhooks — webhook subscriptions
-CREATE TABLE IF NOT EXISTS webhooks (
-  id          INTEGER PRIMARY KEY AUTOINCREMENT,
-  url         TEXT NOT NULL,
-  events_json TEXT,
-  secret      TEXT,
-  status      TEXT DEFAULT 'active' CHECK(status IN ('active','disabled')),
+-- 1. workspaces — workspace container
+CREATE TABLE IF NOT EXISTS workspaces (
+  id          TEXT PRIMARY KEY,              -- 'ws-<hex12>'
+  title       TEXT NOT NULL,
+  slug        TEXT NOT NULL UNIQUE,
+  status      TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active','archived')),
+  root_path   TEXT NOT NULL,
   created_at  TEXT NOT NULL,
   updated_at  TEXT NOT NULL
 );
 
--- 6. artifacts — artifact versioning
-CREATE TABLE IF NOT EXISTS artifacts (
-  id             INTEGER PRIMARY KEY AUTOINCREMENT,
-  run_id         TEXT NOT NULL REFERENCES runs(id),
-  kind           TEXT NOT NULL CHECK(kind IN ('req','design','adr','code','test-report')),
-  path           TEXT NOT NULL,
-  version        INTEGER DEFAULT 1,
-  status         TEXT DEFAULT 'draft' CHECK(status IN ('draft','submitted','approved','rejected')),
-  content_hash   TEXT,
-  byte_size      INTEGER,
-  stage          TEXT,
-  git_ref        TEXT,
-  review_comment TEXT,
-  created_at     TEXT NOT NULL
+-- 2. design_docs — DesignDoc artifact index (created before design_works since
+--    design_works.output_design_doc_id soft-references this table)
+CREATE TABLE IF NOT EXISTS design_docs (
+  id                      TEXT PRIMARY KEY,  -- 'des-<hex12>'
+  workspace_id            TEXT NOT NULL REFERENCES workspaces(id),
+  slug                    TEXT NOT NULL,
+  version                 TEXT NOT NULL,     -- SemVer string '1.0.0'
+  path                    TEXT NOT NULL,
+  parent_version          TEXT,
+  needs_frontend_mockup   INTEGER NOT NULL DEFAULT 0 CHECK(needs_frontend_mockup IN (0,1)),
+  rubric_threshold        INTEGER NOT NULL DEFAULT 85,
+  status                  TEXT NOT NULL DEFAULT 'draft' CHECK(status IN ('draft','published','superseded')),
+  content_hash            TEXT,
+  byte_size               INTEGER,
+  created_at              TEXT NOT NULL,
+  published_at            TEXT,
+  UNIQUE(workspace_id, slug, version)
 );
 
--- 7. agent_hosts — host pool
-CREATE TABLE IF NOT EXISTS agent_hosts (
-  id             TEXT PRIMARY KEY,
-  host           TEXT NOT NULL,
-  agent_type     TEXT NOT NULL CHECK(agent_type IN ('claude','codex','both')),
-  max_concurrent INTEGER DEFAULT 2,
-  ssh_key        TEXT,
-  labels_json    TEXT,
-  status         TEXT DEFAULT 'active' CHECK(status IN ('active','draining','offline')),
-  created_at     TEXT NOT NULL,
-  updated_at     TEXT NOT NULL
+-- 3. design_works — DesignWork state machine instance (process table)
+CREATE TABLE IF NOT EXISTS design_works (
+  id                      TEXT PRIMARY KEY,  -- 'desw-<hex12>'
+  workspace_id            TEXT NOT NULL REFERENCES workspaces(id),
+  mode                    TEXT NOT NULL CHECK(mode IN ('new','optimize')),
+  parent_version          TEXT,
+  needs_frontend_mockup   INTEGER NOT NULL DEFAULT 0 CHECK(needs_frontend_mockup IN (0,1)),
+  current_state           TEXT NOT NULL DEFAULT 'INIT' CHECK(current_state IN ('INIT','MODE_BRANCH','PRE_VALIDATE','PROMPT_COMPOSE','LLM_GENERATE','MOCKUP','POST_VALIDATE','PERSIST','COMPLETED','ESCALATED','CANCELLED')),
+  loop                    INTEGER NOT NULL DEFAULT 0,
+  missing_sections_json   TEXT,
+  agent                   TEXT NOT NULL DEFAULT 'claude' CHECK(agent IN ('claude','codex')),
+  escalated_at            TEXT,
+  user_input_path         TEXT,
+  output_design_doc_id    TEXT,              -- soft reference (no FK, U12)
+  created_at              TEXT NOT NULL,
+  updated_at              TEXT NOT NULL
 );
 
--- 8. jobs — agent job tracking
-CREATE TABLE IF NOT EXISTS jobs (
-  id             TEXT PRIMARY KEY,
-  run_id         TEXT NOT NULL REFERENCES runs(id),
-  host_id        TEXT REFERENCES agent_hosts(id),
-  agent_type     TEXT NOT NULL,
-  stage          TEXT NOT NULL,
-  status         TEXT DEFAULT 'starting' CHECK(status IN ('starting','running','completed','failed','timeout','cancelled','interrupted')),
-  task_file      TEXT,
-  worktree       TEXT,
-  base_commit    TEXT,
-  pid            INTEGER,
-  ssh_session_id TEXT,
-  snapshot_json  TEXT,
-  resume_count   INTEGER DEFAULT 0,
-  session_name   TEXT,
-  turn_count     INTEGER DEFAULT 1,
-  events_file    TEXT,
-  timeout_sec    INTEGER,
-  running_started_at TEXT,
-  started_at     TEXT NOT NULL,
-  ended_at       TEXT
+-- 4. dev_works — DevWork state machine instance + indicator fields
+CREATE TABLE IF NOT EXISTS dev_works (
+  id                          TEXT PRIMARY KEY,  -- 'dev-<hex12>'
+  workspace_id                TEXT NOT NULL REFERENCES workspaces(id),
+  design_doc_id               TEXT NOT NULL REFERENCES design_docs(id),
+  repo_path                   TEXT NOT NULL,
+  prompt                      TEXT NOT NULL,
+  worktree_path               TEXT,
+  worktree_branch             TEXT,
+  current_step                TEXT NOT NULL DEFAULT 'INIT' CHECK(current_step IN ('INIT','STEP1_VALIDATE','STEP2_ITERATION','STEP3_CONTEXT','STEP4_DEVELOP','STEP5_REVIEW','COMPLETED','ESCALATED','CANCELLED')),
+  iteration_rounds            INTEGER NOT NULL DEFAULT 0,
+  first_pass_success          INTEGER CHECK(first_pass_success IN (0,1)),
+  last_score                  INTEGER,
+  last_problem_category       TEXT CHECK(last_problem_category IN ('req_gap','impl_gap','design_hollow') OR last_problem_category IS NULL),
+  agent                       TEXT NOT NULL DEFAULT 'claude' CHECK(agent IN ('claude','codex')),
+  gates_json                  TEXT,
+  escalated_at                TEXT,
+  completed_at                TEXT,
+  created_at                  TEXT NOT NULL,
+  updated_at                  TEXT NOT NULL
 );
 
--- 9. merge_queue — merge ordering
-CREATE TABLE IF NOT EXISTS merge_queue (
-  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-  run_id              TEXT NOT NULL REFERENCES runs(id) UNIQUE,
-  branch              TEXT NOT NULL,
-  priority            INTEGER DEFAULT 0,
-  status              TEXT DEFAULT 'waiting' CHECK(status IN ('waiting','merging','merged','conflict','skipped')),
-  conflict_files_json TEXT,
+-- 5. dev_iteration_notes — iteration design file metadata (markdown body on disk)
+CREATE TABLE IF NOT EXISTS dev_iteration_notes (
+  id                  TEXT PRIMARY KEY,      -- 'note-<hex12>'
+  dev_work_id         TEXT NOT NULL REFERENCES dev_works(id),
+  round               INTEGER NOT NULL,
+  markdown_path       TEXT NOT NULL,
+  score_history_json  TEXT,
   created_at          TEXT NOT NULL,
-  updated_at          TEXT NOT NULL
+  UNIQUE(dev_work_id, round)
 );
 
--- 10. turns — per-turn history within a job
-CREATE TABLE IF NOT EXISTS turns (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    job_id      TEXT NOT NULL REFERENCES jobs(id),
-    turn_num    INTEGER NOT NULL,
-    prompt_file TEXT,
-    verdict     TEXT,
-    detail      TEXT,
-    started_at  TEXT NOT NULL,
-    ended_at    TEXT,
-    UNIQUE(job_id, turn_num)
+-- 6. reviews — Step5 / D5 review records
+CREATE TABLE IF NOT EXISTS reviews (
+  id                      TEXT PRIMARY KEY,  -- 'rev-<hex12>'
+  dev_work_id             TEXT REFERENCES dev_works(id),
+  design_work_id          TEXT REFERENCES design_works(id),
+  dev_iteration_note_id   TEXT REFERENCES dev_iteration_notes(id),
+  round                   INTEGER NOT NULL,
+  score                   INTEGER,
+  issues_json             TEXT,
+  findings_json           TEXT,
+  problem_category        TEXT CHECK(problem_category IN ('req_gap','impl_gap','design_hollow') OR problem_category IS NULL),
+  reviewer                TEXT,
+  created_at              TEXT NOT NULL,
+  CHECK ((dev_work_id IS NOT NULL) OR (design_work_id IS NOT NULL))
 );
 
-CREATE INDEX IF NOT EXISTS idx_turns_job ON turns(job_id);
+-- 7. workspace_events — telemetry event log (pure log, no delivery state)
+CREATE TABLE IF NOT EXISTS workspace_events (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id        TEXT NOT NULL UNIQUE,
+  event_name      TEXT NOT NULL,
+  workspace_id    TEXT REFERENCES workspaces(id),
+  correlation_id  TEXT,
+  payload_json    TEXT,
+  ts              TEXT NOT NULL
+);
 
 -- Indexes
-CREATE INDEX IF NOT EXISTS idx_runs_status   ON runs(status);
-CREATE INDEX IF NOT EXISTS idx_runs_ticket   ON runs(ticket);
-CREATE INDEX IF NOT EXISTS idx_events_run    ON events(run_id);
-CREATE INDEX IF NOT EXISTS idx_events_trace  ON events(trace_id);
-CREATE INDEX IF NOT EXISTS idx_events_job    ON events(job_id);
-CREATE INDEX IF NOT EXISTS idx_events_level  ON events(level);
-CREATE INDEX IF NOT EXISTS idx_events_span   ON events(span_type);
-CREATE INDEX IF NOT EXISTS idx_jobs_run      ON jobs(run_id);
-CREATE INDEX IF NOT EXISTS idx_jobs_status   ON jobs(status);
-CREATE INDEX IF NOT EXISTS idx_artifacts_run ON artifacts(run_id);
+CREATE INDEX IF NOT EXISTS idx_workspaces_status           ON workspaces(status);
+CREATE INDEX IF NOT EXISTS idx_design_works_workspace      ON design_works(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_design_works_state          ON design_works(current_state);
+CREATE INDEX IF NOT EXISTS idx_design_docs_workspace       ON design_docs(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_design_docs_slug            ON design_docs(slug);
+CREATE INDEX IF NOT EXISTS idx_dev_works_workspace         ON dev_works(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_dev_works_step              ON dev_works(current_step);
+CREATE INDEX IF NOT EXISTS idx_dev_works_design_doc        ON dev_works(design_doc_id);
+CREATE INDEX IF NOT EXISTS idx_dev_iteration_notes_work    ON dev_iteration_notes(dev_work_id);
+CREATE INDEX IF NOT EXISTS idx_reviews_dev_work            ON reviews(dev_work_id);
+CREATE INDEX IF NOT EXISTS idx_reviews_design_work         ON reviews(design_work_id);
+CREATE INDEX IF NOT EXISTS idx_reviews_note                ON reviews(dev_iteration_note_id);
+CREATE INDEX IF NOT EXISTS idx_workspace_events_name       ON workspace_events(event_name);
+CREATE INDEX IF NOT EXISTS idx_workspace_events_workspace  ON workspace_events(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_workspace_events_ts         ON workspace_events(ts);

--- a/src/database.py
+++ b/src/database.py
@@ -69,46 +69,58 @@ class Database:
             rows = await cursor.fetchall()
         return any(row["name"] == column for row in rows)
 
-    async def _apply_compat_migrations(self) -> None:
+    async def _table_exists(self, table: str) -> bool:
         conn = self._ensure_connected()
-        if not await self._column_exists("jobs", "timeout_sec"):
-            await conn.execute("ALTER TABLE jobs ADD COLUMN timeout_sec INTEGER")
-        if not await self._column_exists("jobs", "running_started_at"):
-            await conn.execute("ALTER TABLE jobs ADD COLUMN running_started_at TEXT")
+        async with conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return row is not None
 
-        # Tracing columns migration
-        trace_cols = {
-            "trace_id": "TEXT",
-            "job_id": "TEXT",
-            "span_type": "TEXT DEFAULT 'system'",
-            "level": "TEXT DEFAULT 'info'",
-            "duration_ms": "INTEGER",
-            "error_detail": "TEXT",
-            "source": "TEXT",
-        }
-        for col, col_type in trace_cols.items():
-            if not await self._column_exists("events", col):
-                await conn.execute(f"ALTER TABLE events ADD COLUMN {col} {col_type}")
+    async def _apply_compat_migrations(self) -> None:
+        # Phase 1 workspace-driven refactor dropped the legacy tables (runs,
+        # events, jobs, ...). The compat migrations below only apply when those
+        # legacy tables are still present; skip gracefully when the schema has
+        # been rebuilt for the new workspace model.
+        conn = self._ensure_connected()
+        if await self._table_exists("jobs"):
+            if not await self._column_exists("jobs", "timeout_sec"):
+                await conn.execute("ALTER TABLE jobs ADD COLUMN timeout_sec INTEGER")
+            if not await self._column_exists("jobs", "running_started_at"):
+                await conn.execute("ALTER TABLE jobs ADD COLUMN running_started_at TEXT")
 
-        # Make run_id nullable: check notnull flag via PRAGMA
-        async with conn.execute("PRAGMA table_info(events)") as cursor:
-            rows = await cursor.fetchall()
-        for row in rows:
-            if row["name"] == "run_id" and row["notnull"] == 1:
-                await self._migrate_events_nullable_run_id(conn)
-                break
+        if await self._table_exists("events"):
+            trace_cols = {
+                "trace_id": "TEXT",
+                "job_id": "TEXT",
+                "span_type": "TEXT DEFAULT 'system'",
+                "level": "TEXT DEFAULT 'info'",
+                "duration_ms": "INTEGER",
+                "error_detail": "TEXT",
+                "source": "TEXT",
+            }
+            for col, col_type in trace_cols.items():
+                if not await self._column_exists("events", col):
+                    await conn.execute(f"ALTER TABLE events ADD COLUMN {col} {col_type}")
 
-        # Agent preference columns on runs
-        if not await self._column_exists("runs", "design_agent"):
-            await conn.execute("ALTER TABLE runs ADD COLUMN design_agent TEXT DEFAULT 'claude'")
-        if not await self._column_exists("runs", "dev_agent"):
-            await conn.execute("ALTER TABLE runs ADD COLUMN dev_agent TEXT DEFAULT 'claude'")
+            async with conn.execute("PRAGMA table_info(events)") as cursor:
+                rows = await cursor.fetchall()
+            for row in rows:
+                if row["name"] == "run_id" and row["notnull"] == 1:
+                    await self._migrate_events_nullable_run_id(conn)
+                    break
 
-        # Ensure tracing indexes exist
-        await conn.execute("CREATE INDEX IF NOT EXISTS idx_events_trace ON events(trace_id)")
-        await conn.execute("CREATE INDEX IF NOT EXISTS idx_events_job ON events(job_id)")
-        await conn.execute("CREATE INDEX IF NOT EXISTS idx_events_span ON events(span_type)")
-        await conn.execute("CREATE INDEX IF NOT EXISTS idx_events_level ON events(level)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS idx_events_trace ON events(trace_id)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS idx_events_job ON events(job_id)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS idx_events_span ON events(span_type)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS idx_events_level ON events(level)")
+
+        if await self._table_exists("runs"):
+            if not await self._column_exists("runs", "design_agent"):
+                await conn.execute("ALTER TABLE runs ADD COLUMN design_agent TEXT DEFAULT 'claude'")
+            if not await self._column_exists("runs", "dev_agent"):
+                await conn.execute("ALTER TABLE runs ADD COLUMN dev_agent TEXT DEFAULT 'claude'")
 
     async def _migrate_events_nullable_run_id(self, conn) -> None:
         """Rebuild events table to make run_id nullable."""

--- a/src/models.py
+++ b/src/models.py
@@ -95,3 +95,156 @@ class MergeRequest(BaseModel):
     priority: int = 0
 
 
+# ---------------------------------------------------------------------------
+# Phase 1 — Workspace-driven domain models
+# ---------------------------------------------------------------------------
+
+class WorkspaceStatus(str, Enum):
+    active = "active"
+    archived = "archived"
+
+
+class DesignWorkMode(str, Enum):
+    new = "new"
+    optimize = "optimize"
+
+
+class DesignWorkState(str, Enum):
+    INIT = "INIT"
+    MODE_BRANCH = "MODE_BRANCH"
+    PRE_VALIDATE = "PRE_VALIDATE"
+    PROMPT_COMPOSE = "PROMPT_COMPOSE"
+    LLM_GENERATE = "LLM_GENERATE"
+    MOCKUP = "MOCKUP"
+    POST_VALIDATE = "POST_VALIDATE"
+    PERSIST = "PERSIST"
+    COMPLETED = "COMPLETED"
+    ESCALATED = "ESCALATED"
+    CANCELLED = "CANCELLED"
+
+
+class DesignDocStatus(str, Enum):
+    draft = "draft"
+    published = "published"
+    superseded = "superseded"
+
+
+class DevWorkStep(str, Enum):
+    INIT = "INIT"
+    STEP1_VALIDATE = "STEP1_VALIDATE"
+    STEP2_ITERATION = "STEP2_ITERATION"
+    STEP3_CONTEXT = "STEP3_CONTEXT"
+    STEP4_DEVELOP = "STEP4_DEVELOP"
+    STEP5_REVIEW = "STEP5_REVIEW"
+    COMPLETED = "COMPLETED"
+    ESCALATED = "ESCALATED"
+    CANCELLED = "CANCELLED"
+
+
+class ProblemCategory(str, Enum):
+    req_gap = "req_gap"
+    impl_gap = "impl_gap"
+    design_hollow = "design_hollow"
+
+
+class AgentKind(str, Enum):
+    claude = "claude"
+    codex = "codex"
+
+
+class Workspace(BaseModel):
+    id: str
+    title: str
+    slug: str
+    status: WorkspaceStatus = WorkspaceStatus.active
+    root_path: str
+    created_at: str
+    updated_at: str
+
+
+class DesignWork(BaseModel):
+    id: str
+    workspace_id: str
+    mode: DesignWorkMode
+    parent_version: str | None = None
+    needs_frontend_mockup: bool = False
+    current_state: DesignWorkState = DesignWorkState.INIT
+    loop: int = 0
+    missing_sections: list[str] | None = None
+    agent: AgentKind = AgentKind.claude
+    escalated_at: str | None = None
+    user_input_path: str | None = None
+    output_design_doc_id: str | None = None
+    created_at: str
+    updated_at: str
+
+
+class DesignDoc(BaseModel):
+    id: str
+    workspace_id: str
+    slug: str
+    version: str
+    path: str
+    parent_version: str | None = None
+    needs_frontend_mockup: bool = False
+    rubric_threshold: int = 85
+    status: DesignDocStatus = DesignDocStatus.draft
+    content_hash: str | None = None
+    byte_size: int | None = None
+    created_at: str
+    published_at: str | None = None
+
+
+class DevWork(BaseModel):
+    id: str
+    workspace_id: str
+    design_doc_id: str
+    repo_path: str
+    prompt: str
+    worktree_path: str | None = None
+    worktree_branch: str | None = None
+    current_step: DevWorkStep = DevWorkStep.INIT
+    iteration_rounds: int = 0
+    first_pass_success: bool | None = None
+    last_score: int | None = None
+    last_problem_category: ProblemCategory | None = None
+    agent: AgentKind = AgentKind.claude
+    gates: dict | None = None
+    escalated_at: str | None = None
+    completed_at: str | None = None
+    created_at: str
+    updated_at: str
+
+
+class DevIterationNote(BaseModel):
+    id: str
+    dev_work_id: str
+    round: int
+    markdown_path: str
+    score_history: list[int] | None = None
+    created_at: str
+
+
+class Review(BaseModel):
+    id: str
+    dev_work_id: str | None = None
+    design_work_id: str | None = None
+    dev_iteration_note_id: str | None = None
+    round: int
+    score: int | None = None
+    issues: list[dict] | None = None
+    findings: list[dict] | None = None
+    problem_category: ProblemCategory | None = None
+    reviewer: str | None = None
+    created_at: str
+
+
+class WorkspaceEvent(BaseModel):
+    id: int | None = None
+    event_id: str
+    event_name: str
+    workspace_id: str | None = None
+    correlation_id: str | None = None
+    payload: dict | None = None
+    ts: str
+

--- a/src/workspace_manager.py
+++ b/src/workspace_manager.py
@@ -1,0 +1,60 @@
+"""Workspace CRUD — Phase 1 DB layer only.
+
+Filesystem scaffolding (workspace.md, designs/, devworks/) lands in Phase 2.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class WorkspaceManager:
+    def __init__(self, db, project_root=None):
+        self.db = db
+        self.project_root = Path(project_root) if project_root else Path(__file__).resolve().parents[1]
+
+    @staticmethod
+    def _new_id() -> str:
+        return f"ws-{uuid.uuid4().hex[:12]}"
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    async def create(self, title: str, slug: str, root_path: str) -> str:
+        wid = self._new_id()
+        now = self._now()
+        await self.db.execute(
+            """INSERT INTO workspaces(id, title, slug, status, root_path, created_at, updated_at)
+               VALUES(?,?,?,?,?,?,?)""",
+            (wid, title, slug, "active", root_path, now, now),
+        )
+        return wid
+
+    async def get(self, workspace_id: str) -> dict | None:
+        return await self.db.fetchone(
+            "SELECT * FROM workspaces WHERE id=?", (workspace_id,)
+        )
+
+    async def get_by_slug(self, slug: str) -> dict | None:
+        return await self.db.fetchone(
+            "SELECT * FROM workspaces WHERE slug=?", (slug,)
+        )
+
+    async def list(self, status: str | None = None) -> list[dict]:
+        if status:
+            return await self.db.fetchall(
+                "SELECT * FROM workspaces WHERE status=? ORDER BY created_at DESC",
+                (status,),
+            )
+        return await self.db.fetchall(
+            "SELECT * FROM workspaces ORDER BY created_at DESC"
+        )
+
+    async def archive(self, workspace_id: str) -> int:
+        now = self._now()
+        return await self.db.execute_rowcount(
+            "UPDATE workspaces SET status='archived', updated_at=? WHERE id=? AND status='active'",
+            (now, workspace_id),
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,134 @@
+import pytest
+from pydantic import ValidationError
+
+from src.models import (
+    AgentKind,
+    DesignDoc,
+    DesignDocStatus,
+    DesignWork,
+    DesignWorkMode,
+    DesignWorkState,
+    DevIterationNote,
+    DevWork,
+    DevWorkStep,
+    ProblemCategory,
+    Review,
+    Workspace,
+    WorkspaceEvent,
+    WorkspaceStatus,
+)
+
+NOW = "2026-01-01T00:00:00Z"
+
+
+def test_workspace_happy():
+    w = Workspace(
+        id="ws-1", title="T", slug="t", root_path="/tmp/t",
+        created_at=NOW, updated_at=NOW,
+    )
+    assert w.status == WorkspaceStatus.active
+
+
+def test_workspace_missing_required():
+    with pytest.raises(ValidationError):
+        Workspace(id="ws-1")
+
+
+def test_design_work_mode_new_no_parent():
+    dw = DesignWork(
+        id="desw-1", workspace_id="ws-1",
+        mode=DesignWorkMode.new,
+        created_at=NOW, updated_at=NOW,
+    )
+    assert dw.current_state == DesignWorkState.INIT
+    assert dw.parent_version is None
+    assert dw.loop == 0
+    assert dw.agent == AgentKind.claude
+
+
+def test_design_work_mode_optimize_with_parent():
+    dw = DesignWork(
+        id="desw-2", workspace_id="ws-1",
+        mode=DesignWorkMode.optimize, parent_version="1.0.0",
+        agent=AgentKind.codex,
+        created_at=NOW, updated_at=NOW,
+    )
+    assert dw.parent_version == "1.0.0"
+    assert dw.agent == AgentKind.codex
+
+
+def test_design_doc_default_rubric_threshold():
+    dd = DesignDoc(
+        id="des-1", workspace_id="ws-1", slug="abc123def456",
+        version="1.0.0", path="designs/DES-abc123def456-1.0.0.md",
+        created_at=NOW,
+    )
+    assert dd.rubric_threshold == 85
+    assert dd.status == DesignDocStatus.draft
+
+
+def test_dev_work_default_indicators():
+    dw = DevWork(
+        id="dev-1", workspace_id="ws-1", design_doc_id="des-1",
+        repo_path="/repo", prompt="do X",
+        created_at=NOW, updated_at=NOW,
+    )
+    assert dw.iteration_rounds == 0
+    assert dw.first_pass_success is None
+    assert dw.last_score is None
+    assert dw.last_problem_category is None
+    assert dw.agent == AgentKind.claude
+    assert dw.current_step == DevWorkStep.INIT
+
+
+def test_dev_work_problem_category_enum():
+    dw = DevWork(
+        id="dev-2", workspace_id="ws-1", design_doc_id="des-1",
+        repo_path="/repo", prompt="do X",
+        last_problem_category=ProblemCategory.impl_gap,
+        created_at=NOW, updated_at=NOW,
+    )
+    assert dw.last_problem_category == ProblemCategory.impl_gap
+    with pytest.raises(ValidationError):
+        DevWork(
+            id="dev-3", workspace_id="ws-1", design_doc_id="des-1",
+            repo_path="/repo", prompt="do X",
+            last_problem_category="invalid",
+            created_at=NOW, updated_at=NOW,
+        )
+
+
+def test_dev_iteration_note_score_history_list():
+    n = DevIterationNote(
+        id="note-1", dev_work_id="dev-1", round=1,
+        markdown_path="devworks/dev-1/round1.md",
+        score_history=[70, 85],
+        created_at=NOW,
+    )
+    assert n.score_history == [70, 85]
+
+
+def test_review_dev_with_note_link():
+    r = Review(
+        id="rev-1", dev_work_id="dev-1",
+        dev_iteration_note_id="note-1", round=1, created_at=NOW,
+    )
+    assert r.dev_work_id == "dev-1"
+    assert r.dev_iteration_note_id == "note-1"
+
+
+def test_review_design_work_without_note():
+    r = Review(
+        id="rev-2", design_work_id="desw-1", round=1, created_at=NOW,
+    )
+    assert r.design_work_id == "desw-1"
+    assert r.dev_iteration_note_id is None
+
+
+def test_workspace_event_payload_dict():
+    e = WorkspaceEvent(
+        event_id="uuid-1", event_name="workspace.created",
+        workspace_id="ws-1", payload={"title": "T"}, ts=NOW,
+    )
+    assert e.payload["title"] == "T"
+    assert e.id is None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,100 @@
+import pytest
+
+from src.database import Database
+
+
+@pytest.fixture
+async def db(tmp_path):
+    d = Database(db_path=tmp_path / "test.db", schema_path="db/schema.sql")
+    await d.connect()
+    yield d
+    await d.close()
+
+
+EXPECTED_TABLES = {
+    "workspaces",
+    "design_works",
+    "design_docs",
+    "dev_works",
+    "dev_iteration_notes",
+    "reviews",
+    "workspace_events",
+}
+
+REMOVED_TABLES = {
+    "runs",
+    "steps",
+    "events",
+    "approvals",
+    "artifacts",
+    "jobs",
+    "merge_queue",
+    "turns",
+}
+
+NOW = "2026-01-01T00:00:00Z"
+
+
+async def test_expected_tables_exist(db):
+    rows = await db.fetchall(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )
+    names = {r["name"] for r in rows}
+    missing = EXPECTED_TABLES - names
+    assert not missing, f"Missing tables: {missing}"
+
+
+async def test_removed_tables_absent(db):
+    rows = await db.fetchall(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )
+    names = {r["name"] for r in rows}
+    leftover = names & REMOVED_TABLES
+    assert not leftover, f"Old tables still present: {leftover}"
+
+
+async def test_dev_works_indicator_columns(db):
+    rows = await db.fetchall("PRAGMA table_info(dev_works)")
+    cols = {r["name"] for r in rows}
+    assert {
+        "iteration_rounds",
+        "first_pass_success",
+        "last_score",
+        "last_problem_category",
+    }.issubset(cols)
+
+
+async def test_design_docs_unique_workspace_slug_version(db):
+    await db.execute(
+        "INSERT INTO workspaces(id,title,slug,status,root_path,created_at,updated_at) VALUES(?,?,?,?,?,?,?)",
+        ("ws-1", "W1", "w1", "active", "/tmp/w1", NOW, NOW),
+    )
+    await db.execute(
+        "INSERT INTO design_docs(id,workspace_id,slug,version,path,created_at) VALUES(?,?,?,?,?,?)",
+        ("des-1", "ws-1", "abc123def456", "1.0.0", "designs/DES-abc123def456-1.0.0.md", NOW),
+    )
+    with pytest.raises(Exception):
+        await db.execute(
+            "INSERT INTO design_docs(id,workspace_id,slug,version,path,created_at) VALUES(?,?,?,?,?,?)",
+            ("des-2", "ws-1", "abc123def456", "1.0.0", "designs/dup.md", NOW),
+        )
+
+
+async def test_reviews_xor_constraint(db):
+    with pytest.raises(Exception):
+        await db.execute(
+            "INSERT INTO reviews(id,round,created_at) VALUES(?,?,?)",
+            ("rev-null", 1, NOW),
+        )
+
+
+async def test_workspace_events_event_id_unique(db):
+    await db.execute(
+        "INSERT INTO workspace_events(event_id,event_name,ts) VALUES(?,?,?)",
+        ("evt-1", "workspace.created", NOW),
+    )
+    with pytest.raises(Exception):
+        await db.execute(
+            "INSERT INTO workspace_events(event_id,event_name,ts) VALUES(?,?,?)",
+            ("evt-1", "workspace.created", NOW),
+        )

--- a/tests/test_workspace_manager.py
+++ b/tests/test_workspace_manager.py
@@ -1,0 +1,70 @@
+import pytest
+
+from src.database import Database
+from src.workspace_manager import WorkspaceManager
+
+
+@pytest.fixture
+async def db(tmp_path):
+    d = Database(db_path=tmp_path / "test.db", schema_path="db/schema.sql")
+    await d.connect()
+    yield d
+    await d.close()
+
+
+@pytest.fixture
+async def wm(db, tmp_path):
+    return WorkspaceManager(db, project_root=tmp_path)
+
+
+async def test_create_and_get(wm):
+    wid = await wm.create(title="Feature X", slug="feature-x", root_path="/tmp/ws/feature-x")
+    assert wid.startswith("ws-")
+    w = await wm.get(wid)
+    assert w is not None
+    assert w["title"] == "Feature X"
+    assert w["status"] == "active"
+    assert w["slug"] == "feature-x"
+    assert w["root_path"] == "/tmp/ws/feature-x"
+
+
+async def test_get_by_slug(wm):
+    wid = await wm.create(title="Feature Y", slug="feature-y", root_path="/tmp/ws/feature-y")
+    w = await wm.get_by_slug("feature-y")
+    assert w is not None
+    assert w["id"] == wid
+
+
+async def test_get_missing_returns_none(wm):
+    assert await wm.get("ws-missing") is None
+    assert await wm.get_by_slug("not-here") is None
+
+
+async def test_list_filters_status(wm):
+    w1 = await wm.create(title="A", slug="a", root_path="/tmp/a")
+    w2 = await wm.create(title="B", slug="b", root_path="/tmp/b")
+    await wm.archive(w2)
+
+    active_ids = {w["id"] for w in await wm.list(status="active")}
+    archived_ids = {w["id"] for w in await wm.list(status="archived")}
+    all_ids = {w["id"] for w in await wm.list()}
+
+    assert active_ids == {w1}
+    assert archived_ids == {w2}
+    assert all_ids == {w1, w2}
+
+
+async def test_archive_idempotent(wm):
+    wid = await wm.create(title="Z", slug="z", root_path="/tmp/z")
+    assert await wm.archive(wid) == 1
+    assert await wm.archive(wid) == 0
+
+
+async def test_archive_unknown_id_returns_zero(wm):
+    assert await wm.archive("ws-nope") == 0
+
+
+async def test_duplicate_slug_raises(wm):
+    await wm.create(title="Dup", slug="dup", root_path="/tmp/dup")
+    with pytest.raises(Exception):
+        await wm.create(title="Dup2", slug="dup", root_path="/tmp/dup2")


### PR DESCRIPTION
## Summary

Phase 1 of the workspace-driven task refactor ([PRD](.claude/PRPs/prds/workspace-driven-task-refactor.prd.md)). Breaking rebuild of the database schema around a Workspace-centric model so later phases don't have to fight legacy `runs` / `artifacts` plumbing.

- Drop the legacy 10-table schema (`runs`, `steps`, `events`, `approvals`, `artifacts`, `jobs`, `merge_queue`, `turns`, `webhooks`, `agent_hosts`) and replace with the new 7 tables: `workspaces`, `design_docs`, `design_works`, `dev_works`, `dev_iteration_notes`, `reviews`, `workspace_events`.
- Indicator fields (`iteration_rounds`, `first_pass_success`, `last_score`, `last_problem_category`) land natively on `dev_works` so Phase 8 metrics can `SELECT` without joins.
- Add 7 Pydantic models + 7 enums in `src/models.py` (legacy DTOs kept for incremental migration — Phase 7 cleans them up).
- New `WorkspaceManager` with minimal CRUD (`create` / `get` / `get_by_slug` / `list` / `archive`); filesystem scaffolding lands in Phase 2.
- `src/database.py::_apply_compat_migrations` guarded with table-existence checks so `connect()` stays clean on the new schema and a no-op on any remaining legacy DB. The whole compat block is removed in Phase 7.

## Why

The old schema hard-wired the state machine around `runs` + `artifacts.version INTEGER` + three fixed gates, with no room for SemVer design docs, DesignWork process instances, or metrics. Phase 1 lays the contract so Phases 2-8 can build directly on `workspaces` instead of bolting onto `runs`.

## Scope boundaries (intentional)

- Phase 1 is data-layer only — **no** state machine behavior, file scaffolding, validator, OpenClaw envelope, or routes. See `## NOT Building` in the plan.
- Legacy tests referencing `runs` / `artifacts` (e.g. `tests/test_artifact_manager.py`) are **expected to stay red** until Phase 7 removes the old managers. The new Phase 1 test files are all green.

## Deviation from plan

`src/database.py::_apply_compat_migrations` was not called out in the plan but had to be gated: with the legacy tables dropped, the first `Database.connect()` would raise `no such table: jobs` on `ALTER TABLE`. Minimal `_table_exists` guards only — no behavior change for DBs that still have the legacy tables.

## Test plan

- [x] `pytest tests/test_schema.py tests/test_models.py tests/test_workspace_manager.py -v` — 24/24 pass
- [x] DB verification: `sqlite_master` returns exactly the 7 new tables, zero legacy tables
- [x] Pydantic round-trip: enum validation rejects bad strings, defaults populate, three-valued `first_pass_success` preserved
- [ ] Full `pytest` suite — will fail on legacy `test_artifact_manager.py` / `test_state_machine.py` (expected; Phase 7)

## Files

| File | Action |
|---|---|
| `db/schema.sql` | Rewrite |
| `src/models.py` | Append 7 enums + 7 BaseModels |
| `src/workspace_manager.py` | New |
| `src/database.py` | Guard compat migrations |
| `tests/test_schema.py` | New — 6 tests |
| `tests/test_models.py` | New — 11 tests |
| `tests/test_workspace_manager.py` | New — 7 tests |

## Follow-ups

- Phase 2: extend `WorkspaceManager` to scaffold `workspace.md` / `designs/` / `devworks/`
- Phase 7: delete legacy managers + compat migration block, restore full-suite green